### PR TITLE
Get metrics from the circuit breakers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 	implementation("com.google.guava:guava:31.0.1-jre")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.apache.httpcomponents:httpclient:${httpclientVersion}")
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("io.github.resilience4j:resilience4j-micrometer:1.7.0")
 	testImplementation("junit:junit:4.13.2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 }


### PR DESCRIPTION
This PR brings 2 changes:
1. According to the Spring Cloud Circuit Breaker documentation, CircuitBreakerFactory should be injected into beans [1]. And that factory is configured by using a Customizer which is passed the factory [2].

[1] https://docs.spring.io/spring-cloud-commons/docs/current/reference/html/#spring-cloud-circuit-breaker
[2] https://docs.spring.io/spring-cloud-circuitbreaker/docs/current/reference/html/#specific-circuit-breaker-configuration

2. The first change brings us the advantage of easily being able to get metrics from the circuit breaker. When adding the right dependencies, we are able to get metrics from Spring Cloud Circuit Breaker Resilience4j [3].

[3] https://docs.spring.io/spring-cloud-circuitbreaker/docs/current/reference/html/#collecting-metrics